### PR TITLE
Replace lerp with smootherstep in perlinimage example

### DIFF
--- a/examples/perlinimage.rs
+++ b/examples/perlinimage.rs
@@ -2,7 +2,7 @@ use glam::{Vec2, Vec3};
 use image::{Rgba, RgbaImage};
 use rhachis::{
     graphics::Renderer,
-    math::lerp,
+    math::smootherstep,
     rand::{perlin_2d, Noise},
     renderers::{Model, SimpleRenderer, Texture, Transform},
     *,
@@ -24,7 +24,7 @@ impl Game for PerlinImage {
 
         for x in 0..IMAGE_WIDTH {
             for y in 0..IMAGE_HEIGHT {
-                let perlin = perlin_2d(&noise, Vec2::new(x as f32, y as f32) / 64.0, lerp);
+                let perlin = perlin_2d(&noise, Vec2::new(x as f32, y as f32) / 64.0, smootherstep);
                 let value = ((perlin + 1.0) * 127.0) as u8;
                 image.put_pixel(x, y, Rgba([value, value, value, 255]));
             }


### PR DESCRIPTION
Lerp caused visual artifacts like this:

![image](https://user-images.githubusercontent.com/40014472/194041428-de977320-7314-4d04-ad46-0a8da99a6200.png)

Smootherstep looks like this:

![image](https://user-images.githubusercontent.com/40014472/194041511-1e73b778-8dd1-488b-a23e-fc6547bc8743.png)
